### PR TITLE
Refactor AdvancedSearch, separate logic from simple search

### DIFF
--- a/src/components/advanced-search/index.tsx
+++ b/src/components/advanced-search/index.tsx
@@ -1,38 +1,98 @@
-import React, { type FC, SyntheticEvent, ChangeEvent } from 'react';
-import './style.scss';
-import { INTOLERANCES, CUISINES } from '../../constants';
+import React, { type FC, SyntheticEvent, ChangeEvent, FormEvent, useState } from 'react';
+import { useHistory } from 'react-router';
+import { useDispatch } from 'react-redux';
+import axios from 'axios';
 import MultiSelectCheckbox from '../multi-select-checkbox';
+import { INTOLERANCES, CUISINES } from '../../constants';
+import { setSearchResults } from '../../redux/slices/search-results';
+import './style.scss';
 
 interface AdvancedSearchProps {
-  onSubmit: Function;
   backToSimpleSearch: Function;
-  handleKeywordChange: Function;
-  handleCheckboxSelect: Function;
 }
 
 const AdvancedSearch = (props: AdvancedSearchProps) => {
-  const { onSubmit, backToSimpleSearch, handleKeywordChange, handleCheckboxSelect } = props;
+  const { backToSimpleSearch } = props;
 
-  const callOnSubmit = (event: SyntheticEvent) => {
-    onSubmit(event);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCheckboxIntolerances, setSelectedCheckboxIntolerances] = useState<string[]>([]);
+  const [selectedCheckboxCuisines, setSelectedCheckboxCuisines] = useState<string[]>([]);
+  const apiKey = process.env.REACT_APP_SPOONACULAR_API_KEY;
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // let searchPath = `/search?query=${searchQuery}`
+    // const intolerancesParam = selectedCheckboxIntolerances.length > 0 ? ``
+    // history.push(`/search?query=${searchQuery}`);
+    // To abstract this to its own hook, pass in searchQuery, selectedIntolerances, selectedCuisines
+    try {
+      // setIsSearchSubmitted(true);
+      const queryString = `&query=${searchQuery}`;
+      const intolerances = selectedCheckboxIntolerances.join(',');
+      const intolerancesQueryString = `&intolerances=${intolerances}`;
+      const cuisines = selectedCheckboxCuisines.join(',');
+      const cuisinesQueryString = `&cuisine=${cuisines}`;
+
+      setSearchQuery(searchQuery);
+
+      let recipesSearchUrl = `https://api.spoonacular.com/recipes/complexSearch?apiKey=${apiKey}&addRecipeInformation=true&number=200`;
+
+      if (searchQuery) {
+        recipesSearchUrl = `${recipesSearchUrl}${queryString}`;
+      }
+      if (intolerances && intolerances.length > 0) {
+        recipesSearchUrl = `${recipesSearchUrl}${intolerancesQueryString}`;
+      }
+      if (cuisines && cuisines.length > 0) {
+        recipesSearchUrl = `${recipesSearchUrl}${cuisinesQueryString}`;
+      }
+
+      const fetchRecipes = async () => {
+        await axios.get(recipesSearchUrl).then((response) => {
+          if (response.data && response.data.totalResults === 0) {
+            // setCouldNotFindRecipes(true);
+            // TODO: Handle couldNotFindRecipes
+            console.log('COULD NOT FIND RECIPES');
+          } else {
+            console.log('response.data.results', response.data.results);
+            // TODO: Check up on this
+            dispatch(setSearchResults(response.data.results));
+            history.push('/search-results');
+          }
+        });
+      };
+      fetchRecipes();
+    } catch (error) {
+      // TODO: Add toast error, or UI indication of some kind
+      console.error(error);
+    }
   };
 
-  const handleChange = (event: ChangeEvent) => {
-    handleKeywordChange(event);
+  const handleKeywordChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const target = event.target;
+    setSearchQuery(target.value);
+    // dispatch(setKeyword(target.value));
   };
 
-  const handleSelect = (selectedOptions: string[], filterType: string) => {
-    handleCheckboxSelect(selectedOptions, filterType);
+  const handleCheckboxSelect = (filters: string[], filterType: string) => {
+    if (filterType === 'intolerances') {
+      setSelectedCheckboxIntolerances(filters);
+    }
+    if (filterType === 'cuisines') {
+      setSelectedCheckboxCuisines(filters);
+    }
   };
 
   return (
-    <form className="advanced-search" onSubmit={callOnSubmit}>
+    <form className="advanced-search" onSubmit={onSubmit}>
       <input
         className="text-field"
         type="text"
         name="keyword"
         placeholder="Type a keyword"
-        onChange={handleChange}
+        onChange={handleKeywordChange}
       ></input>
       <button className="search-button" type="submit">
         Search
@@ -44,13 +104,13 @@ const AdvancedSearch = (props: AdvancedSearchProps) => {
         <MultiSelectCheckbox
           filterType="intolerances"
           options={INTOLERANCES}
-          handleSelect={handleSelect}
+          handleSelect={handleCheckboxSelect}
           label="Intolerances to omit:"
         />
         <MultiSelectCheckbox
           filterType="cuisines"
           options={CUISINES}
-          handleSelect={handleSelect}
+          handleSelect={handleCheckboxSelect}
           label="Filter by cuisine-type:"
         />
       </div>

--- a/src/components/multi-select-checkbox/index.tsx
+++ b/src/components/multi-select-checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useEffect, useState } from 'react';
+import React, { ChangeEvent, MouseEvent, useEffect, useState } from 'react';
 import './style.scss';
 
 interface MultiSelectCheckboxProps {
@@ -32,6 +32,13 @@ const MultiSelectCheckbox = (props: MultiSelectCheckboxProps) => {
     handleSelect(selectedOptions, filterType);
   };
 
+  const removeOption = (event: MouseEvent<HTMLButtonElement>, option: string) => {
+    event?.preventDefault();
+    console.log('option', option);
+    const updatedSelectedOptions = selectedOptions.filter((opt) => option !== opt);
+    setSelectedOptions(updatedSelectedOptions);
+  };
+
   return (
     <div className="multiselect-checkbox">
       <div className="multiselect-label">{label}</div>
@@ -39,12 +46,13 @@ const MultiSelectCheckbox = (props: MultiSelectCheckboxProps) => {
         {selectedOptions.length > 0 ? (
           <div className="filters-container">
             {selectedOptions.map((option, index) => {
+              console.log('option:', option);
               return (
                 <div className="selected-option">
                   <div id={option} key={`input-${option}-${index}`}>
                     {option}
                   </div>
-                  <button className="close">
+                  <button className="close" onClick={(event) => removeOption(event, option)}>
                     <i className="fas fa-times-circle"></i>
                   </button>
                 </div>
@@ -66,6 +74,7 @@ const MultiSelectCheckbox = (props: MultiSelectCheckboxProps) => {
                   name={option.value}
                   type="checkbox"
                   onChange={onChange}
+                  checked={selectedOptions.includes(option.value)}
                 ></input>
                 <label htmlFor={option.value}>{option.label}</label>
               </div>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FormEvent, SyntheticEvent, useEffect, useState } from 'react';
+import React, { ChangeEvent, FormEvent, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import axios from 'axios';
@@ -9,8 +9,6 @@ import { setSearchResults } from '../../redux/slices/search-results';
 const Home = () => {
   const [isAdvancedSearch, setIsAdvancedSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedCheckboxIntolerances, setSelectedCheckboxIntolerances] = useState<string[]>([]);
-  const [selectedCheckboxCuisines, setSelectedCheckboxCuisines] = useState<string[]>([]);
   const apiKey = process.env.REACT_APP_SPOONACULAR_API_KEY;
   const history = useHistory();
   const dispatch = useDispatch();
@@ -19,15 +17,6 @@ const Home = () => {
     const target = event.target;
     setSearchQuery(target.value);
     // dispatch(setKeyword(target.value));
-  };
-
-  const handleCheckboxSelect = (filters: string[], filterType: string) => {
-    if (filterType === 'intolerances') {
-      setSelectedCheckboxIntolerances(filters);
-    }
-    if (filterType === 'cuisines') {
-      setSelectedCheckboxCuisines(filters);
-    }
   };
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -39,23 +28,11 @@ const Home = () => {
     try {
       // setIsSearchSubmitted(true);
       const queryString = `&query=${searchQuery}`;
-      const intolerances = selectedCheckboxIntolerances.join(',');
-      const intolerancesQueryString = `&intolerances=${intolerances}`;
-      const cuisines = selectedCheckboxCuisines.join(',');
-      const cuisinesQueryString = `&cuisine=${cuisines}`;
-
       setSearchQuery(searchQuery);
-
       let recipesSearchUrl = `https://api.spoonacular.com/recipes/complexSearch?apiKey=${apiKey}&addRecipeInformation=true&number=200`;
 
       if (searchQuery) {
         recipesSearchUrl = `${recipesSearchUrl}${queryString}`;
-      }
-      if (intolerances && intolerances.length > 0) {
-        recipesSearchUrl = `${recipesSearchUrl}${intolerancesQueryString}`;
-      }
-      if (cuisines && cuisines.length > 0) {
-        recipesSearchUrl = `${recipesSearchUrl}${cuisinesQueryString}`;
       }
 
       const fetchRecipes = async () => {
@@ -95,17 +72,10 @@ const Home = () => {
       <div className="overlay">
         <div className="search-form-container">
           <h1 className="main-header">Welcome to Recipedia</h1>
-          <h3 className="sub-header">
-            When you just need a recipe without the author's life story
-          </h3>
+          <h3 className="sub-header">Recipes without the authors' life stories</h3>
           <h3 className="search-label">What's on the menu?</h3>
           {isAdvancedSearch ? (
-            <AdvancedSearch
-              onSubmit={onSubmit}
-              backToSimpleSearch={backToSimpleSearch}
-              handleKeywordChange={handleKeywordChange}
-              handleCheckboxSelect={handleCheckboxSelect}
-            />
+            <AdvancedSearch backToSimpleSearch={backToSimpleSearch} />
           ) : (
             <form onSubmit={onSubmit}>
               <input


### PR DESCRIPTION
This moves the onSubmit logic and form state for AdvancedSearch out of Home and into AdvancedSearch, so simple search and advanced are completely separate for now. I may consolidate the submit logic into a hook but for now it's just about cleaning things up.