### PR TITLE
Add searchQuery reducer

### DIFF
--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,21 +1,23 @@
 import React, { ChangeEvent, FormEvent, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 import './style.scss';
+import { type RootState } from '../../redux/root-reducer';
 import AdvancedSearch from '../../components/advanced-search';
 import { setSearchResults } from '../../redux/slices/search-results';
+import { setSearchQuery } from '../../redux/slices/search-query';
 
 const Home = () => {
   const [isAdvancedSearch, setIsAdvancedSearch] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
+  const searchQuery = useSelector((state: RootState) => state.searchQuery);
   const apiKey = process.env.REACT_APP_SPOONACULAR_API_KEY;
   const history = useHistory();
   const dispatch = useDispatch();
 
   const handleKeywordChange = (event: ChangeEvent<HTMLInputElement>) => {
     const target = event.target;
-    setSearchQuery(target.value);
+    dispatch(setSearchQuery(target.value));
     // dispatch(setKeyword(target.value));
   };
 
@@ -28,7 +30,6 @@ const Home = () => {
     try {
       // setIsSearchSubmitted(true);
       const queryString = `&query=${searchQuery}`;
-      setSearchQuery(searchQuery);
       let recipesSearchUrl = `https://api.spoonacular.com/recipes/complexSearch?apiKey=${apiKey}&addRecipeInformation=true&number=200`;
 
       if (searchQuery) {

--- a/src/pages/search-results/index.tsx
+++ b/src/pages/search-results/index.tsx
@@ -16,6 +16,7 @@ const SearchResults = () => {
 
   const { search } = useLocation();
   const recipes = useSelector((state: RootState) => state.searchResults);
+  const searchQuery = useSelector((state: RootState) => state.searchQuery);
   // const { query } = queryString.parse(search);
 
   const resultsPerPage = 10;
@@ -44,7 +45,7 @@ const SearchResults = () => {
     <div className="recipe-results-container">
       {recipes.length > 0 ? (
         <div>
-          {/* <h3>{`Showing ${recipes.length} results for "${searchQuery}"`}</h3> */}
+          <h3>{`Showing ${recipes.length} results for "${searchQuery}"`}</h3>
           {/* <button onClick={() => refreshSearch()}>Back to Search</button> */}
           <div className="recipe-results">
             {recipes.map(

--- a/src/redux/root-reducer.ts
+++ b/src/redux/root-reducer.ts
@@ -1,8 +1,10 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import searchResultsReducer from './slices/search-results';
+import searchQueryReducer from './slices/search-query';
 
 const rootReducer = combineReducers({
   searchResults: searchResultsReducer,
+  searchQuery: searchQueryReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/redux/slices/search-query.js
+++ b/src/redux/slices/search-query.js
@@ -1,0 +1,14 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const searchQuerySlice = createSlice({
+  name: 'searchQuery',
+  initialState: '',
+  reducers: {
+    setSearchQuery: (state, action) => {
+      return action.payload;
+    },
+  },
+});
+
+export const { setSearchQuery } = searchQuerySlice.actions;
+export default searchQuerySlice.reducer;


### PR DESCRIPTION
This adds a searchQuery reducer. It was needed for the search results page for "Showing X results for [searchQuery]" and may be used elsewhere as needed.

<img width="887" alt="Screen Shot 2023-10-13 at 12 13 26 AM" src="https://github.com/TobiasNorton/recipedia/assets/44213270/07295806-ea74-4f60-af9d-942af7f8290a">
